### PR TITLE
Replace byte-masking macros with direct casts. PostgreSQL 11+ compatibility.

### DIFF
--- a/src/ajbool.h
+++ b/src/ajbool.h
@@ -3,9 +3,9 @@
 #include "fmgr.h"
 
 typedef int8 ajbool;
-#define DatumGetAjBool(X) ((ajbool) GET_1_BYTE(X))
-#define AjBoolGetDatum(X) ((Datum) SET_1_BYTE(X))
 
+#define DatumGetAjBool(X) ((ajbool) (X))
+#define AjBoolGetDatum(X) ((Datum) (X))
 #define PG_GETARG_AJBOOL(n)    DatumGetAjBool(PG_GETARG_DATUM(n))
 #define PG_RETURN_AJBOOL(x)    return AjBoolGetDatum(x)
 

--- a/test/expected/parallel_test_0.out
+++ b/test/expected/parallel_test_0.out
@@ -1,0 +1,44 @@
+BEGIN;
+SET max_parallel_workers_per_gather=4;
+SET force_parallel_mode=on;
+CREATE TABLE parallel_test(i int, data ajbool) WITH (parallel_workers = 4);
+INSERT INTO parallel_test
+SELECT i, CASE i%3 WHEN 0 THEN 't' WHEN 1 THEN 'f' ELSE 'u' END::ajbool as data
+FROM generate_series(1,1e6) i;
+EXPLAIN (costs off,verbose)
+SELECT COUNT(*) FROM parallel_test WHERE data;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather
+         Output: (PARTIAL count(*))
+         Workers Planned: 4
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Parallel Seq Scan on public.parallel_test
+                     Output: i, data
+                     Filter: parallel_test.data
+(10 rows)
+
+EXPLAIN (costs off,verbose)
+SELECT data, COUNT(*) FROM parallel_test GROUP BY 1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: data, count(*)
+   Group Key: parallel_test.data
+   ->  Gather Merge
+         Output: data, (PARTIAL count(*))
+         Workers Planned: 4
+         ->  Sort
+               Output: data, (PARTIAL count(*))
+               Sort Key: parallel_test.data
+               ->  Partial HashAggregate
+                     Output: data, PARTIAL count(*)
+                     Group Key: parallel_test.data
+                     ->  Parallel Seq Scan on public.parallel_test
+                           Output: i, data
+(14 rows)
+
+ROLLBACK;


### PR DESCRIPTION
Byte-masking macros has been removed from PostgreSQL 11 and  upstream at
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a6ef00b5c3c4a287e03b634d328529b69cc1e770