### PR TITLE
Improve Travis Builds and add PostgreSQL 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 sudo: required
 dist: xenial
 language: c
+before_install:
+   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+   - curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+   - sudo apt-get update
 matrix:
    include:
      - addons: 
           postgresql: 9.3
           apt:
             packages:
+               - postgresql-9.3
+               - postgresql-client-9.3
                - postgresql-server-dev-9.3
        env:
           - POSTGRESQL=9.3
+          - PGPORT=5433
        install:
            - sudo make install
      - addons: 
@@ -48,6 +55,18 @@ matrix:
           - POSTGRESQL=10
        install:
            - sudo make install
+     - addons:
+          postgresql: 11
+          apt:
+            packages:
+               - postgresql-11
+               - postgresql-client-11
+               - postgresql-server-dev-11
+       env:
+          - POSTGRESQL=11
+          - PGPORT=5433
+       install:
+         - sudo make install
 script:
   - make installcheck
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,53 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: c
 matrix:
    include:
      - addons: 
           postgresql: 9.3
+          apt:
+            packages:
+               - postgresql-server-dev-9.3
        env:
           - POSTGRESQL=9.3
        install:
-           - sudo apt-get install postgresql-server-dev-9.3
            - sudo make install
      - addons: 
           postgresql: 9.4
+          apt:
+            packages:
+               - postgresql-server-dev-9.4
        env:
           - POSTGRESQL=9.4
        install:
-           - sudo apt-get install postgresql-server-dev-9.4
            - sudo make install
      - addons: 
           postgresql: 9.5
-       install:
-           - sudo apt-get install postgresql-server-dev-9.5
-           - sudo make install
+          apt:
+            packages:
+               - postgresql-server-dev-9.5
        env:
           - POSTGRESQL=9.5
-     - addons: 
-          postgresql: 9.6
        install:
-           - sudo apt-get install postgresql-server-dev-9.6
            - sudo make install
+     - addons:
+          postgresql: 9.6
+          apt:
+            packages:
+               - postgresql-server-dev-9.6
        env:
           - POSTGRESQL=9.6
-     - # addons: postgresql: 10
        install:
-           - sudo service postgresql stop
-           - wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
-           - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
-           - sudo apt-get update
-           - sudo apt-get install postgresql postgresql-contrib postgresql-client
-           - sudo apt-get install postgresql-server-dev-10
-           - sudo sh -c 'echo "port=5432" >> /etc/postgresql/10/main/postgresql.conf'
-           - sudo pg_ctlcluster 10 main restart
-           - sudo -u postgres psql  -c "create user travis with superuser";
            - sudo make install
+     - addons:
+          postgresql: 10
+          apt:
+            packages:
+               - postgresql-server-dev-10
        env:
           - POSTGRESQL=10
+       install:
+           - sudo make install
 script:
   - make installcheck
 after_failure:


### PR DESCRIPTION
Update travis machine to xenial and install PostgeSQL 9.3 (EOL) and PostgreSQL 11 from the PGDG packages. At the moment of commit this fails with PostgreSQL 11, but only because the actual code
base is not updated.

There is a slight inefficiency of installing pgdg repo and doing updates for all cases, so far it doesn't pose a slowdown for 9.4 - 10 cases and we can look into addressing it further down the line in a sane way (without copy-pasting the stuff all over).